### PR TITLE
Allow users to use strides in Tensor creation

### DIFF
--- a/examples/tensor_tests/CMakeLists.txt
+++ b/examples/tensor_tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+#policy CMP0076 - target_sources source files are relative to file where target_sources is run
+cmake_policy (SET CMP0076 NEW)
+
+set(PROJECT_NAME test_tensor)
+
+project(${PROJECT_NAME} LANGUAGES Fortran)
+
+# Build in Debug mode if not specified
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+endif()
+
+find_package(FTorch)
+message(STATUS "Building with Fortran PyTorch coupling")
+
+# Some tests for tensor generation.
+add_executable(test_tensor test_tensor.f90)
+target_link_libraries(test_tensor PRIVATE FTorch::ftorch)

--- a/examples/tensor_tests/test_tensor.f90
+++ b/examples/tensor_tests/test_tensor.f90
@@ -48,8 +48,12 @@ program test_tensor
   call torch_tensor_print(output_tensor)
 
   shape_2D_F = shape(uuu_flattened)
-  output_tensor = torch_tensor_from_array(uuu_flattened, shape_2D_F, torch_kCPU)
+  output_tensor = torch_tensor_from_array_c_double(uuu_flattened, shape_2D_F, torch_kCPU)
 
+  call torch_tensor_print(output_tensor)
+
+  output_tensor = torch_tensor_from_array(uuu_flattened, shape_2D_F, torch_kCPU)
+  
   call torch_tensor_print(output_tensor)
 
   ! output_tensor = torch_tensor_zeros( &

--- a/examples/tensor_tests/test_tensor.f90
+++ b/examples/tensor_tests/test_tensor.f90
@@ -1,0 +1,48 @@
+program test_tensor
+  use, intrinsic :: iso_c_binding, only: c_int64_t, c_float, c_char, c_null_char, c_ptr, c_loc
+  use ftorch
+  implicit none
+
+  real(kind=8), dimension(:,:), allocatable, target  :: uuu_flattened, vvv_flattened
+  real(kind=8), dimension(:,:), allocatable, target    :: lat_reshaped, psfc_reshaped
+  real(kind=8), dimension(:,:), allocatable, target  :: gwfcng_x_flattened, gwfcng_y_flattened
+  type(torch_tensor), target :: output_tensor
+  integer(c_int), parameter :: dims_1D = 2
+  integer(c_int), parameter :: dims_2D = 2
+  integer(c_int64_t) :: shape_2D_F(dims_2D), shape_2D_C(dims_2D)
+  integer(c_int64_t) :: shape_1D_F(dims_1D), shape_1D_C(dims_1D)
+  integer(c_int) :: layout_F(dims_1D), layout_C(dims_1D)
+  integer :: imax, jmax, kmax, i, j, k
+
+  imax = 1
+  jmax = 5
+  kmax = 7
+
+  shape_2D_F = (/ kmax, imax*jmax /)
+  shape_1D_F = (/ 1, imax*jmax /)
+  shape_2D_C = (/ imax*jmax, kmax /)
+  shape_1D_C = (/ imax*jmax, 1 /)
+
+  layout_F = (/ 1, 2 /)
+  layout_C = (/ 2, 1 /)
+
+  allocate( lat_reshaped(imax*jmax, 1) )
+  allocate( uuu_flattened(imax*jmax, kmax) )
+  do i = 1, imax*jmax
+    lat_reshaped(i, 1) = i
+    do k = 1, kmax
+      uuu_flattened(i, k) = i + k*100
+    end do
+  end do
+
+
+  output_tensor = torch_tensor_from_blob(c_loc(uuu_flattened), &
+  dims_2D, shape_2D_C, torch_kFloat64, torch_kCPU, layout_F)
+
+  call torch_tensor_print(output_tensor)
+
+  output_tensor = torch_tensor_from_blob(c_loc(uuu_flattened), &
+  dims_2D, shape_2D_F, torch_kFloat64, torch_kCPU, layout_C)
+
+  call torch_tensor_print(output_tensor)
+end program test_tensor

--- a/examples/tensor_tests/test_tensor.f90
+++ b/examples/tensor_tests/test_tensor.f90
@@ -35,6 +35,7 @@ program test_tensor
     end do
   end do
 
+  write(*,*) uuu_flattened
 
   output_tensor = torch_tensor_from_blob(c_loc(uuu_flattened), &
   dims_2D, shape_2D_C, torch_kFloat64, torch_kCPU, layout_F)
@@ -45,4 +46,20 @@ program test_tensor
   dims_2D, shape_2D_F, torch_kFloat64, torch_kCPU, layout_C)
 
   call torch_tensor_print(output_tensor)
+
+  shape_2D_F = shape(uuu_flattened)
+  output_tensor = torch_tensor_from_array(uuu_flattened, shape_2D_F, torch_kCPU)
+
+  call torch_tensor_print(output_tensor)
+
+  ! output_tensor = torch_tensor_zeros( &
+  ! dims_2D, shape_2D_C, torch_kFloat64, torch_kCPU)
+
+  ! call torch_tensor_print(output_tensor)
+
+  ! output_tensor = torch_tensor_ones( &
+  ! dims_2D, shape_2D_C, torch_kFloat64, torch_kCPU)
+
+  ! call torch_tensor_print(output_tensor)
+
 end program test_tensor

--- a/fortran-pytorch-lib/ctorch.cpp
+++ b/fortran-pytorch-lib/ctorch.cpp
@@ -109,6 +109,7 @@ torch_tensor_t torch_empty(int ndim, const int64_t* shape, torch_data_t dtype,
   return tensor;
 }
 
+/*
 // Exposes the given data as a Tensor without taking ownership of the original
 // data
 torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
@@ -122,6 +123,35 @@ torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
     *tensor = torch::from_blob(
         data, vshape,
         torch::dtype(get_dtype(dtype)).device(get_device(device)));
+  } catch (const torch::Error& e) {
+    std::cerr << "[ERROR]: " << e.msg() << std::endl;
+    delete tensor;
+    exit(EXIT_FAILURE);
+  } catch (const std::exception& e) {
+    std::cerr << "[ERROR]: " << e.what() << std::endl;
+    delete tensor;
+    exit(EXIT_FAILURE);
+  }
+  return tensor;
+}
+
+*/
+// New version of torch_from_blob that uses strides
+torch_tensor_t torch_from_blob(void* data, int ndim, const int64_t* shape,
+                               const int64_t* strides, torch_data_t dtype,
+                               torch_device_t device)
+{
+  torch::Tensor* tensor = nullptr;
+
+  try {
+    // This doesn't throw if shape and dimensions are incompatible
+    c10::IntArrayRef vshape(shape, ndim);
+    c10::IntArrayRef vstrides(strides, ndim);
+    tensor = new torch::Tensor;
+    *tensor = torch::from_blob(
+        data, vshape, vstrides,
+        torch::dtype(get_dtype(dtype)).device(get_device(device)));
+
   } catch (const torch::Error& e) {
     std::cerr << "[ERROR]: " << e.msg() << std::endl;
     delete tensor;

--- a/fortran-pytorch-lib/ctorch.h
+++ b/fortran-pytorch-lib/ctorch.h
@@ -73,6 +73,7 @@ EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
  */
 EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
                                         const int64_t* shape,
+                                        const int64_t* strides,
                                         torch_data_t dtype,
                                         torch_device_t device);
 
@@ -81,6 +82,22 @@ EXPORT_C torch_tensor_t torch_from_blob(void* data, int ndim,
  * @param Torch Tensor to print
  */
 EXPORT_C void torch_tensor_print(const torch_tensor_t tensor);
+
+/**
+ * Function to create a Torch Tensor from memory location given extra information
+ * This is a rework for torch_from_blob that uses strides, and will eventually
+ * replace torch_from_blob.
+ * @param pointer to the Tensor in memory
+ * @param number of dimensions of the Tensor
+ * @param shape of the Tensor
+ * @param data type of the elements of the Tensor
+ * @param device used (cpu, CUDA, etc.)
+ * @return Torch Tensor interpretation of the data pointed at
+ */
+EXPORT_C torch_tensor_t torch_from_blob_f(void* data, int ndim,
+                                        const int64_t* shape,
+                                        torch_data_t dtype,
+                                        torch_device_t device);
 
 /**
  * Function to delete a Torch Tensor to clean up

--- a/fortran-pytorch-lib/ctorch.h
+++ b/fortran-pytorch-lib/ctorch.h
@@ -67,6 +67,7 @@ EXPORT_C torch_tensor_t torch_empty(int ndim, const int64_t* shape,
  * @param pointer to the Tensor in memory
  * @param number of dimensions of the Tensor
  * @param shape of the Tensor
+ * @param strides to take through data
  * @param data type of the elements of the Tensor
  * @param device used (cpu, CUDA, etc.)
  * @return Torch Tensor interpretation of the data pointed at

--- a/fortran-pytorch-lib/ftorch.f90
+++ b/fortran-pytorch-lib/ftorch.f90
@@ -34,11 +34,11 @@ contains
    ! Torch Tensor API
    !> Exposes the given data as a tensor without taking ownership of the original data.
    !> This routine will take an (i, j, k) array and return an (k, j, i) tensor.
-   function torch_tensor_from_blob(data, ndims, shape, dtype, device, layout) result(tensor)
+   function torch_tensor_from_blob(data, ndims, tensor_shape, dtype, device, layout) result(tensor)
       use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
       type(c_ptr), intent(in)        :: data       !! Pointer to data
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
-      integer(c_int64_t), intent(in) :: shape(*)   !! Shape of the tensor
+      integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
       integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
       integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
@@ -48,12 +48,12 @@ contains
       integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
 
       interface
-         function torch_from_blob_c(data, ndims, shape, strides, dtype, device) result(tensor) &
+         function torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device) result(tensor) &
             bind(c, name='torch_from_blob')
             use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
             type(c_ptr), value, intent(in)    :: data
             integer(c_int), value, intent(in) :: ndims
-            integer(c_int64_t), intent(in)    :: shape(*)
+            integer(c_int64_t), intent(in)    :: tensor_shape(*)
             integer(c_int64_t), intent(in)    :: strides(*)
             integer(c_int), value, intent(in) :: dtype
             integer(c_int), value, intent(in) :: device
@@ -63,33 +63,33 @@ contains
 
       strides(layout(1)) = 1
       do i = 2, ndims
-        strides(layout(i)) = strides(layout(i-1)) * shape(layout(i-1))
+        strides(layout(i)) = strides(layout(i-1)) * tensor_shape(layout(i-1))
       end do
-      tensor%p = torch_from_blob_c(data, ndims, shape, strides, dtype, device)
+      tensor%p = torch_from_blob_c(data, ndims, tensor_shape, strides, dtype, device)
    end function torch_tensor_from_blob
 
    !> Returns a tensor filled with the scalar value 1.
-   function torch_tensor_ones(ndims, shape, dtype, device) result(tensor)
+   function torch_tensor_ones(ndims, tensor_shape, dtype, device) result(tensor)
       use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
-      integer(c_int64_t), intent(in) :: shape(*)   !! Shape of the tensor
+      integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
       integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
       type(torch_tensor)             :: tensor     !! Returned tensor
 
       interface
-         function torch_ones_c(ndims, shape, dtype, device) result(tensor) &
+         function torch_ones_c(ndims, tensor_shape, dtype, device) result(tensor) &
             bind(c, name='torch_ones')
             use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
             integer(c_int), value, intent(in) :: ndims
-            integer(c_int64_t), intent(in)    :: shape(*)
+            integer(c_int64_t), intent(in)    :: tensor_shape(*)
             integer(c_int), value, intent(in) :: dtype
             integer(c_int), value, intent(in) :: device
             type(c_ptr)                       :: tensor
          end function torch_ones_c
       end interface
 
-      tensor%p = torch_ones_c(ndims, shape, dtype, device)
+      tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device)
    end function torch_tensor_ones
 
    !> Prints the contents of a tensor.

--- a/fortran-pytorch-lib/ftorch.f90
+++ b/fortran-pytorch-lib/ftorch.f90
@@ -33,29 +33,39 @@ contains
 
    ! Torch Tensor API
    !> Exposes the given data as a tensor without taking ownership of the original data.
-   function torch_tensor_from_blob(data, ndims, shape, dtype, device) result(tensor)
+   !> This routine will take an (i, j, k) array and return an (k, j, i) tensor.
+   function torch_tensor_from_blob(data, ndims, shape, dtype, device, layout) result(tensor)
       use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
       type(c_ptr), intent(in)        :: data       !! Pointer to data
       integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
       integer(c_int64_t), intent(in) :: shape(*)   !! Shape of the tensor
       integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
       integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      integer(c_int), intent(in)     :: layout(*)  !! Layout for strides for accessing data
       type(torch_tensor)             :: tensor     !! Returned tensor
 
+      integer(c_int)                 :: i          !! loop index
+      integer(c_int64_t)             :: strides(ndims) !! Strides for accessing data
+
       interface
-         function torch_from_blob_c(data, ndims, shape, dtype, device) result(tensor) &
+         function torch_from_blob_c(data, ndims, shape, strides, dtype, device) result(tensor) &
             bind(c, name='torch_from_blob')
             use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
             type(c_ptr), value, intent(in)    :: data
             integer(c_int), value, intent(in) :: ndims
             integer(c_int64_t), intent(in)    :: shape(*)
+            integer(c_int64_t), intent(in)    :: strides(*)
             integer(c_int), value, intent(in) :: dtype
             integer(c_int), value, intent(in) :: device
             type(c_ptr)                       :: tensor
          end function torch_from_blob_c
       end interface
 
-      tensor%p = torch_from_blob_c(data, ndims, shape, dtype, device)
+      strides(layout(1)) = 1
+      do i = 2, ndims
+        strides(layout(i)) = strides(layout(i-1)) * shape(layout(i-1))
+      end do
+      tensor%p = torch_from_blob_c(data, ndims, shape, strides, dtype, device)
    end function torch_tensor_from_blob
 
    !> Returns a tensor filled with the scalar value 1.

--- a/fortran-pytorch-lib/ftorch.f90
+++ b/fortran-pytorch-lib/ftorch.f90
@@ -92,6 +92,30 @@ contains
       tensor%p = torch_ones_c(ndims, tensor_shape, dtype, device)
    end function torch_tensor_ones
 
+   !> Returns a tensor filled with the scalar value 0.
+   function torch_tensor_zeros(ndims, tensor_shape, dtype, device) result(tensor)
+      use, intrinsic :: iso_c_binding, only : c_int, c_int64_t
+      integer(c_int), intent(in)     :: ndims      !! Number of dimensions of the tensor
+      integer(c_int64_t), intent(in) :: tensor_shape(*)   !! Shape of the tensor
+      integer(c_int), intent(in)     :: dtype      !! Data type of the tensor
+      integer(c_int), intent(in)     :: device     !! Device on which the tensor will live on (torch_kCPU or torch_kGPU)
+      type(torch_tensor)             :: tensor     !! Returned tensor
+
+      interface
+         function torch_zeros_c(ndims, tensor_shape, dtype, device) result(tensor) &
+            bind(c, name='torch_zeros')
+            use, intrinsic :: iso_c_binding, only : c_int, c_int64_t, c_ptr
+            integer(c_int), value, intent(in) :: ndims
+            integer(c_int64_t), intent(in)    :: tensor_shape(*)
+            integer(c_int), value, intent(in) :: dtype
+            integer(c_int), value, intent(in) :: device
+            type(c_ptr)                       :: tensor
+         end function torch_zeros_c
+      end interface
+
+      tensor%p = torch_zeros_c(ndims, tensor_shape, dtype, device)
+   end function torch_tensor_zeros
+
    !> Prints the contents of a tensor.
    subroutine torch_tensor_print(tensor)
       type(torch_tensor), intent(in) :: tensor     !! Input tensor


### PR DESCRIPTION
As documented in #24.  Essentially by wrapping the PyTorch `torch::from_blob` functions (https://pytorch.org/cppdocs/api/namespace_torch.html#namespace-torch) that take `strides` as an argument we can permit users to implicitly transform their data.  E.g. from Fortran indexing to C, or vice-versa.

We will provide Fortran interfaces to suit ordinary and power users.