### PR TITLE
Fixing typos in the README of the ResNet18 example

### DIFF
--- a/examples/1_ResNet18/README.md
+++ b/examples/1_ResNet18/README.md
@@ -59,7 +59,7 @@ cd build
 cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/>lib/cmake/ -DCMAKE_BUILD_TYPE=Release
 make
 ```
-Make sure that the  `FTorch_DIR` flag points to the `/lib/cmake/` folder within the directory of this library.  
+Make sure that the  `FTorch_DIR` flag points to the `lib/cmake/` folder within the installation of the FTorch library.  
 
 To run the compiled code calling the saved ResNet-18 TorchScript from Fortran run the
 executable with an argument of the saved model file:

--- a/examples/1_ResNet18/README.md
+++ b/examples/1_ResNet18/README.md
@@ -56,7 +56,7 @@ This can be done using the included `CMakeLists.txt` as follows:
 ```
 mkdir build
 cd build
-cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/lib/cmake/> -DCMAKE_BUILD_TYPE=Release
+cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/>lib/cmake/ -DCMAKE_BUILD_TYPE=Release
 make
 ```
 Make sure that the  `FTorch_DIR` flag points to the `/lib/cmake/` folder within the directory of this library.  

--- a/examples/1_ResNet18/README.md
+++ b/examples/1_ResNet18/README.md
@@ -56,9 +56,10 @@ This can be done using the included `CMakeLists.txt` as follows:
 ```
 mkdir build
 cd build
-cmake .. -DFTorchDIR=<path/to/your/installation/of/library> -DCMAKE_BUILD_TYPE=Release
+cmake .. -DFTorch_DIR=<path/to/your/installation/of/library/lib/cmake/> -DCMAKE_BUILD_TYPE=Release
 make
 ```
+Make sure that the  `FTorch_DIR` flag points to the `/lib/cmake/` folder within the directory of this library.  
 
 To run the compiled code calling the saved ResNet-18 TorchScript from Fortran run the
 executable with an argument of the saved model file:


### PR DESCRIPTION
closes #26 . When following the [README](https://github.com/Cambridge-ICCS/fortran-pytorch-lib/blob/main/examples/1_ResNet18/README.md) of the ResNet18 example I found some typos in the instructions for the compilation of the `resnet_infer` files.