### PR TITLE
Update deprecated pytorch arguments in ResNet example.

### DIFF
--- a/examples/1_ResNet18/resnet18.py
+++ b/examples/1_ResNet18/resnet18.py
@@ -17,7 +17,7 @@ def initialize():
 
     # Load a pre-trained PyTorch model
     print("Loading pre-trained ResNet-18 model...", end="")
-    model = torchvision.models.resnet18(pretrained=True)
+    model = torchvision.models.resnet18(weights="IMAGENET1K_V1")
     print("done.")
 
     # Switch-off some specific layers/parts of the model that behave


### PR DESCRIPTION
As title says.

Closes #30 